### PR TITLE
Add background layers

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -92,7 +92,7 @@
 
           <hr />
 
-          <div id="background-layers-list"></div>
+          <ul id="background-layers-list" class="side-menu-list"></ul>
         </section>
 
         <section id="tab-token" class="tab-panel" hidden>

--- a/client/index.html
+++ b/client/index.html
@@ -92,7 +92,12 @@
 
           <hr />
 
-          <ul id="background-layers-list" class="side-menu-list"></ul>
+          <label for="background-list-checkbox">
+            <span>Display background list</span>
+            <input type="checkbox" id="background-list-checkbox" />
+          </label>
+
+          <ul id="background-layers-list" class="side-menu-list" style="display: none;"></ul>
         </section>
 
         <section id="tab-token" class="tab-panel" hidden>

--- a/client/index.html
+++ b/client/index.html
@@ -36,12 +36,12 @@
             <span>Select Color</span>
             <input type="color" id="draw-color-input" />
           </label>
-          
+
           <label>
             <span>Border only</span>
             <input type="checkbox" id="draw-border-checkbox" />
           </label>
-          
+
           <label>
             <span>Width</span>
             <input type="number" id="draw-border-number" min="1" max="100" step="1" value="4" />
@@ -63,14 +63,14 @@
             <input type="checkbox" id="grid-global-checkbox" />
             <span>Default grid-lock</span>
           </label>
-          
+
           <hr />
 
           <label for="grid-size">
             <span>Grid-size</span>
             <input id="grid-size" type="number" name="grid-size" min="16" max="2048" step="1" value="64" />
           </label>
-              
+
           <label for="grid-offset-X">
             <span>X-offset</span>
             <input id="grid-offset-X" type="number" name="grid-offset-X" min="0" step="1" value="0" />
@@ -80,13 +80,19 @@
             <span>Y-offset</span>
             <input id="grid-offset-Y" type="number" name="grid-offset-Y" min="0" step="1" value="0" />
           </label>
+        </section>
 
+        <section id="tab-background" class="tab-panel" hidden>
+          <h2>Background</h2>
           <hr />
-
           <label for="upload-background-button" class="label-button">
             <i class="fa-regular fa-image"></i> Upload background
             <input id="upload-background-button" type="file" accept="image/*" style="display: none" />
           </label>
+
+          <hr />
+
+          <div id="background-layers-list"></div>
         </section>
 
         <section id="tab-token" class="tab-panel" hidden>
@@ -97,25 +103,34 @@
             <span>X</span>
             <input id="token-edit-x" type="number" name="token-edit-x" min="0" step="1" value="64" disabled />
           </label>
-            
+
           <label for="token-edit-y">
             <span>Y</span>
             <input id="token-edit-y" type="number" name="token-edit-y" min="0" step="1" value="64" disabled />
           </label>
-          
+
           <label for="token-edit-w">
             <span>Width</span>
             <input id="token-edit-w" type="number" name="token-edit-w" min="8" step="1" value="64" disabled />
           </label>
-          
+
           <label for="token-edit-h">
             <span>Height</span>
             <input id="token-edit-h" type="number" name="token-edit-h" min="8" step="1" value="64" disabled />
           </label>
-          
+
           <label for="token-edit-r">
             <span>Rotate</span>
-            <input id="token-edit-r" type="number" name="token-edit-r" min="-180" max="180" step="1" value="0" disabled />
+            <input
+              id="token-edit-r"
+              type="number"
+              name="token-edit-r"
+              min="-180"
+              max="180"
+              step="1"
+              value="0"
+              disabled
+            />
           </label>
 
           <button id="token-edit-delete" disabled>Delete</button>
@@ -143,7 +158,7 @@
             <span>Color</span>
             <input id="user-input-color" type="color" name="user-input-color" />
           </label>
-          
+
           <hr />
 
           <ul id="user-list" class="side-menu-list"></ul>
@@ -154,6 +169,7 @@
         <button class="tab-close-button" id="sidebar-hide-button"><i class="fa-solid fa-xmark"></i></button>
         <button class="tab-button" data-tab="draw">Draw</button>
         <button class="tab-button" data-tab="grid">Grid</button>
+        <button class="tab-button" data-tab="background">Background</button>
         <button class="tab-button" data-tab="token">Token</button>
         <button class="tab-button" data-tab="user">User</button>
       </nav>

--- a/client/src/components/AutosizeInput.ts
+++ b/client/src/components/AutosizeInput.ts
@@ -7,13 +7,14 @@
 export default function AutosizeInput(value: string = "", minWidth: number = 4) {
   const input = document.createElement("input");
   input.value = value;
+  input.style.fontFamily = "'Courier New', monospace";
 
   const width = Math.max(value.length, minWidth);
-  input.style.width = `${width}ch`;
+  input.size = width;
 
   input.addEventListener("input", () => {
     const width = Math.max(input.value.length, minWidth);
-    input.style.width = `${width}ch`;
+    input.size = width;
   });
   return input;
 }

--- a/client/src/components/AutosizeInput.ts
+++ b/client/src/components/AutosizeInput.ts
@@ -1,0 +1,19 @@
+/**
+ * Create an input element that automatically resizes itself based on its current value.
+ * @param value The starting input value.
+ * @param minWidth The minimum width of the input element.
+ * @returns
+ */
+export default function AutosizeInput(value: string = "", minWidth: number = 4) {
+  const input = document.createElement("input");
+  input.value = value;
+
+  const width = Math.max(value.length, minWidth);
+  input.style.width = `${width}ch`;
+
+  input.addEventListener("input", () => {
+    const width = Math.max(input.value.length, minWidth);
+    input.style.width = `${width}ch`;
+  });
+  return input;
+}

--- a/client/src/controllers/background.ts
+++ b/client/src/controllers/background.ts
@@ -1,7 +1,6 @@
 import type Background from "../models/background";
 import type State from "../state";
 import type Store from "../store";
-import { util } from "../util";
 import type BackgroundView from "../views/background";
 import Controller from "./controller";
 
@@ -9,25 +8,11 @@ class BackgroundController extends Controller<BackgroundView> {
   constructor(store: Store, state: State, view: BackgroundView) {
     super(store, state, view);
 
-    this.view.listen("background_upload", (file) => this.upload(file));
     this.state.listen("background_change", (background) => this.update(background));
   }
 
   public update(background: Background) {
     this.view.set(background.href, background.width, background.height);
-  }
-
-  public async upload(file: File) {
-    const base64 = await util.readBase64(file);
-    if (!base64) throw `Could not read file data.`;
-
-    // Set the image locally
-    const { href: localHref, width, height } = await util.createLocalImage(base64);
-    this.state.setBackground(localHref, width, height);
-
-    // Upload the image to the server
-    const href = await this.store.uploadImage(base64);
-    this.store.send({ type: "request_background", href });
   }
 }
 

--- a/client/src/controllers/backgroundlist.ts
+++ b/client/src/controllers/backgroundlist.ts
@@ -41,6 +41,12 @@ class BackgroundListController extends Controller<BackgroundListView> {
   public deleteLayer(id: string) {
     this.state.deleteBackgroundLayer(id);
     this.store.send({ type: "request_background_delete_layer", id });
+
+    // If deleting the current background layer, set the background to null
+    if (id === this.state.getCurrentBackgroundLayer()) {
+      this.state.selectBackgroundLayer(null);
+      this.store.send({ type: "request_background_select_layer", id: null });
+    }
   }
 
   public renameLayer(id: string, name: string) {

--- a/client/src/controllers/backgroundlist.ts
+++ b/client/src/controllers/backgroundlist.ts
@@ -1,0 +1,57 @@
+import type { BackgroundLayer } from "../models/background";
+import type State from "../state";
+import type Store from "../store";
+import { util } from "../util";
+import type BackgroundListView from "../views/backgroundlist";
+import Controller from "./controller";
+
+class BackgroundListController extends Controller<BackgroundListView> {
+  constructor(store: Store, state: State, view: BackgroundListView) {
+    super(store, state, view);
+
+    this.view.listen("background_upload", (file) => this.upload(file));
+    this.view.listen("background_layer_rename", ([id, name]) => this.renameLayer(id, name));
+    this.view.listen("background_layer_delete", (id) => this.deleteLayer(id));
+    this.view.listen("background_layer_select", (id) => this.selectLayer(id));
+
+    this.state.listen("background_change", (background) => this.view.update(background));
+  }
+
+  public async upload(file: File) {
+    // Upload a background layer to the server and set it immediately
+    const id = crypto.randomUUID();
+    const name = "Unnamed background";
+
+    const base64 = await util.readBase64(file);
+    if (!base64) throw `Could not read file data.`;
+
+    // Set the image locally
+    const { href: localHref, width, height } = await util.createLocalImage(base64);
+    const localLayer: BackgroundLayer = { id, name, href: localHref, width, height };
+    this.state.addBackgroundLayer(localLayer);
+    this.state.selectBackgroundLayer(id);
+
+    // Upload the background to the server
+    const href = await this.store.uploadImage(base64);
+    const layer: BackgroundLayer = { id, name, href, width, height };
+    this.store.send({ type: "request_background_add_layer", layer });
+    this.store.send({ type: "request_background_select_layer", id });
+  }
+
+  public deleteLayer(id: string) {
+    this.state.deleteBackgroundLayer(id);
+    this.store.send({ type: "request_background_delete_layer", id });
+  }
+
+  public renameLayer(id: string, name: string) {
+    this.state.renameBackgroundLayer(id, name);
+    this.store.send({ type: "request_background_rename_layer", id, name });
+  }
+
+  public selectLayer(id: string) {
+    this.state.selectBackgroundLayer(id);
+    this.store.send({ type: "request_background_select_layer", id });
+  }
+}
+
+export default BackgroundListController;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -95,6 +95,11 @@ store.listen("message", (event) => {
       break;
     }
 
+    case "background_rename_layer": {
+      state.renameBackgroundLayer(data.id, data.name);
+      break;
+    }
+
     case "transform":
       state.transformToken(data.transform);
       break;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -28,12 +28,15 @@ import ServerStatusController from "./controllers/serverstatus";
 import type { ResponseMessage } from "./messages";
 import UserCursorController from "./controllers/usercursors";
 import UserCursorsView from "./views/usercursors";
+import BackgroundListView from "./views/backgroundlist";
+import BackgroundListController from "./controllers/backgroundlist";
 
 const state = new State();
 const store = new Store(server.url);
 
 const tokenView = new TokenMapView();
 const backgroundView = new BackgroundView();
+const backgroundListView = new BackgroundListView();
 const transformView = new TransformView(state.grid);
 const selectionView = new SelectionView();
 const serverStatusView = new ServerStatusView();
@@ -47,6 +50,7 @@ const userCursorView = new UserCursorsView(state.grid);
 const hoverView = new HoverView();
 
 new BackgroundController(store, state, backgroundView);
+new BackgroundListController(store, state, backgroundListView);
 new TokenMapController(store, state, tokenView);
 new TransformController(store, state, transformView);
 new SelectionController(store, state, selectionView);
@@ -76,8 +80,18 @@ store.listen("message", (event) => {
       state.setGrid(data.grid);
       break;
 
-    case "background": {
-      state.setBackground(data.background.href, data.background.width, data.background.height);
+    case "background_add_layer": {
+      state.addBackgroundLayer(data.layer);
+      break;
+    }
+
+    case "background_delete_layer": {
+      state.deleteBackgroundLayer(data.id);
+      break;
+    }
+
+    case "background_select_layer": {
+      state.selectBackgroundLayer(data.id);
       break;
     }
 
@@ -97,7 +111,7 @@ store.listen("message", (event) => {
       state.clearTokens();
       state.clearSelected();
       state.setGrid(data.grid);
-      state.setBackground(data.background.href, data.background.width, data.background.height);
+      state.setBackground(data.background.layers, data.background.selected);
       state.createTokens(data.tokens);
       state.setUsers(data.users);
       store.setSecretToken(data.secret);

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -1,3 +1,5 @@
+import type { BackgroundRequestMessage, BackgroundResponseMessage } from "./messages/background";
+import type { BackgroundLayer } from "./models/background";
 import type { GridData } from "./models/grid";
 import type { Token } from "./models/token";
 import type { Point, Transform } from "./models/transform";
@@ -19,9 +21,8 @@ export interface SyncRequestMessage {
 export interface SyncResponseMessage {
   type: "sync";
   background: {
-    href: string | null;
-    width: number;
-    height: number;
+    selected: string | null;
+    layers: BackgroundLayer[];
   };
   grid: GridData;
   tokens: Token[];
@@ -102,22 +103,6 @@ export interface GridRequestMessage {
 export interface GridResponseMessage {
   type: "grid";
   grid: GridData;
-}
-
-/** Request to change the background image */
-export interface BackgroundRequestMessage {
-  type: "request_background";
-  href: string;
-}
-
-/** Set the background image */
-export interface BackgroundResponseMessage {
-  type: "background";
-  background: {
-    href: string | null;
-    width: number;
-    height: number;
-  };
 }
 
 /** Request to update your user */

--- a/client/src/messages/background.ts
+++ b/client/src/messages/background.ts
@@ -15,13 +15,13 @@ export interface BackgroundAddLayerResponseMessage {
 /** Request to select a background layer */
 export interface BackgroundSelectLayerRequestMessage {
   type: "request_background_select_layer";
-  id: string;
+  id: string | null;
 }
 
 /** Select a background layer */
 export interface BackgroundSelectLayerResponseMessage {
   type: "background_select_layer";
-  id: string;
+  id: string | null;
 }
 
 /** Request to rename a background layer */

--- a/client/src/messages/background.ts
+++ b/client/src/messages/background.ts
@@ -33,7 +33,7 @@ export interface BackgroundRenameLayerRequestMessage {
 
 /** Rename a background layer */
 export interface BackgroundRenameLayerResponseMessage {
-  type: "background_select_layer";
+  type: "background_rename_layer";
   id: string;
   name: string;
 }

--- a/client/src/messages/background.ts
+++ b/client/src/messages/background.ts
@@ -1,0 +1,63 @@
+import type { BackgroundLayer } from "../models/background";
+
+/** Request to add a background layer */
+export interface BackgroundAddLayerRequestMessage {
+  type: "request_background_add_layer";
+  layer: BackgroundLayer;
+}
+
+/** Add a background layer */
+export interface BackgroundAddLayerResponseMessage {
+  type: "background_add_layer";
+  layer: BackgroundLayer;
+}
+
+/** Request to select a background layer */
+export interface BackgroundSelectLayerRequestMessage {
+  type: "request_background_select_layer";
+  id: string;
+}
+
+/** Select a background layer */
+export interface BackgroundSelectLayerResponseMessage {
+  type: "background_select_layer";
+  id: string;
+}
+
+/** Request to rename a background layer */
+export interface BackgroundRenameLayerRequestMessage {
+  type: "request_background_rename_layer";
+  id: string;
+  name: string;
+}
+
+/** Rename a background layer */
+export interface BackgroundRenameLayerResponseMessage {
+  type: "background_select_layer";
+  id: string;
+  name: string;
+}
+
+/** Request to delete a background layer */
+export interface BackgroundDeleteLayerRequestMessage {
+  type: "request_background_delete_layer";
+  id: string;
+}
+
+/** Select a background layer */
+export interface BackgroundDeleteLayerResponseMessage {
+  type: "background_delete_layer";
+  id: string;
+}
+
+export type BackgroundRequestMessage =
+  | BackgroundAddLayerRequestMessage
+  | BackgroundSelectLayerRequestMessage
+  | BackgroundRenameLayerRequestMessage
+  | BackgroundDeleteLayerRequestMessage;
+
+export type BackgroundResponseMessage =
+  | BackgroundAddLayerResponseMessage
+  | BackgroundSelectLayerResponseMessage
+  | BackgroundRenameLayerResponseMessage
+  | BackgroundDeleteLayerResponseMessage;

--- a/client/src/models/background.ts
+++ b/client/src/models/background.ts
@@ -1,18 +1,43 @@
+export interface BackgroundLayer {
+  id: string;
+  name: string;
+  href: string | null;
+  width: number;
+  height: number;
+}
+
 class Background {
-  public href: string | null;
-  public width: number;
-  public height: number;
+  public layers: BackgroundLayer[];
+  public selected: string | null;
 
   constructor() {
-    this.href = null;
-    this.width = 1024;
-    this.height = 1024;
+    this.layers = [];
+    this.selected = null;
   }
 
-  public set(href: string | null, width: number, height: number) {
-    this.href = href;
-    this.width = width;
-    this.height = height;
+  public get layer(): BackgroundLayer | null {
+    return this.layers.find((layer) => layer.id === this.selected) ?? null;
+  }
+
+  public get width() {
+    return this.layer?.width ?? 1024;
+  }
+
+  public get height() {
+    return this.layer?.height ?? 1024;
+  }
+
+  public get href() {
+    return this.layer?.href ?? null;
+  }
+
+  public set(layers: BackgroundLayer[], selected: string | null) {
+    this.layers = layers;
+    this.selected = selected;
+  }
+
+  public select(selected: string) {
+    this.selected = selected;
   }
 }
 

--- a/client/src/models/background.ts
+++ b/client/src/models/background.ts
@@ -36,7 +36,7 @@ class Background {
     this.selected = selected;
   }
 
-  public select(selected: string) {
+  public select(selected: string | null) {
     this.selected = selected;
   }
 }

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -49,7 +49,7 @@ class State extends Listener<StateListenerMap> {
     this.emit("background_change", this.background);
   }
 
-  public selectBackgroundLayer(id: string) {
+  public selectBackgroundLayer(id: string | null) {
     this.background.select(id);
     this.emit("background_change", this.background);
   }

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -67,6 +67,10 @@ class State extends Listener<StateListenerMap> {
     }
   }
 
+  public getCurrentBackgroundLayer() {
+    return this.background.selected;
+  }
+
   public createToken(token: Token) {
     this.tokens.push(token);
     this.emit("token_create", token);

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -1,5 +1,5 @@
 import { Listener } from "./listener";
-import Background from "./models/background";
+import Background, { type BackgroundLayer } from "./models/background";
 import Grid, { type GridData } from "./models/grid";
 import type { Token } from "./models/token";
 import type { Transform } from "./models/transform";
@@ -39,9 +39,32 @@ class State extends Listener<StateListenerMap> {
     this.background = new Background();
   }
 
-  public setBackground(href: string | null, width: number, height: number) {
-    this.background.set(href, width, height);
+  public setBackground(layers: BackgroundLayer[], selected: string | null) {
+    this.background.set(layers, selected);
     this.emit("background_change", this.background);
+  }
+
+  public addBackgroundLayer(layer: BackgroundLayer) {
+    this.background.layers.push(layer);
+    this.emit("background_change", this.background);
+  }
+
+  public selectBackgroundLayer(id: string) {
+    this.background.select(id);
+    this.emit("background_change", this.background);
+  }
+
+  public deleteBackgroundLayer(id: string) {
+    this.background.layers = this.background.layers.filter((layer) => layer.id !== id);
+    this.emit("background_change", this.background);
+  }
+
+  public renameBackgroundLayer(id: string, name: string) {
+    const layer = this.background.layers.find((layer) => layer.id === id);
+    if (layer) {
+      layer.name = name;
+      this.emit("background_change", this.background);
+    }
   }
 
   public createToken(token: Token) {

--- a/client/src/views/background.ts
+++ b/client/src/views/background.ts
@@ -1,34 +1,18 @@
-import { Listener } from "../listener";
 import server from "../server";
 
-interface BackgroundViewMap {
-  background_upload: File;
-}
-
-class BackgroundView extends Listener<BackgroundViewMap> {
-  public readonly input: HTMLInputElement;
+class BackgroundView {
   public readonly image: SVGImageElement;
-  public readonly layers: SVGSVGElement[];
+  public readonly whiteboardLayers: SVGSVGElement[];
 
   constructor() {
-    super();
-
-    this.input = document.getElementById("upload-background-button") as HTMLInputElement;
     this.image = document.getElementById("whiteboard-background-image") as unknown as SVGImageElement;
-    this.layers = [
+    this.whiteboardLayers = [
       document.getElementById("whiteboard-background-layer") as unknown as SVGSVGElement,
       document.getElementById("whiteboard-objects-layer") as unknown as SVGSVGElement,
       document.getElementById("whiteboard-drawing-layer") as unknown as SVGSVGElement,
       document.getElementById("whiteboard-resize") as unknown as SVGSVGElement,
       document.getElementById("user-cursors-container") as unknown as SVGSVGElement,
     ];
-
-    this.input.onchange = (evt) => {
-      const file = (evt.target as HTMLInputElement).files?.item(0);
-      if (file) {
-        this.emit("background_upload", file);
-      }
-    };
   }
 
   public set(href: string | null, width: number, height: number) {
@@ -40,7 +24,7 @@ class BackgroundView extends Listener<BackgroundViewMap> {
 
     this.image.setAttribute("width", `${width}px`);
     this.image.setAttribute("height", `${height}px`);
-    for (const layer of this.layers) {
+    for (const layer of this.whiteboardLayers) {
       layer.setAttribute("width", `${width}px`);
       layer.setAttribute("height", `${height}px`);
     }

--- a/client/src/views/backgroundlist.ts
+++ b/client/src/views/backgroundlist.ts
@@ -1,0 +1,55 @@
+import { Listener } from "../listener";
+import type Background from "../models/background";
+
+interface BackgroundListViewMap {
+  background_layer_rename: [string, string];
+  background_layer_select: string;
+  background_layer_delete: string;
+  background_upload: File;
+}
+
+class BackgroundListView extends Listener<BackgroundListViewMap> {
+  public readonly input: HTMLInputElement;
+  public readonly layersDiv: HTMLDivElement;
+
+  constructor() {
+    super();
+
+    this.input = document.getElementById("upload-background-button") as HTMLInputElement;
+    this.layersDiv = document.getElementById("background-layers-list") as HTMLDivElement;
+
+    this.input.onchange = (evt) => {
+      const file = (evt.target as HTMLInputElement).files?.item(0);
+      if (file) {
+        this.emit("background_upload", file);
+      }
+    };
+  }
+
+  public update(background: Background) {
+    this.layersDiv.replaceChildren();
+
+    // Iterate in reverse order
+    const layers = [...background.layers].reverse();
+    for (const layer of layers) {
+      const div = document.createElement("div");
+      const name = document.createElement("p");
+
+      div.id = `background-layer-${layer.id}`;
+      div.onclick = () => this.emit("background_layer_select", layer.id);
+      name.innerText = layer.name;
+
+      if (layer.id === background.selected) {
+        name.style.color = "red";
+      }
+
+      div.appendChild(name);
+      this.layersDiv.appendChild(div);
+    }
+
+    console.log(this.layersDiv);
+    console.log(background);
+  }
+}
+
+export default BackgroundListView;

--- a/client/src/views/backgroundlist.ts
+++ b/client/src/views/backgroundlist.ts
@@ -13,12 +13,14 @@ interface BackgroundListViewMap {
 class BackgroundListView extends Listener<BackgroundListViewMap> {
   public readonly input: HTMLInputElement;
   public readonly layersDiv: HTMLDivElement;
+  public readonly toggleButton: HTMLInputElement;
 
   constructor() {
     super();
 
     this.input = document.getElementById("upload-background-button") as HTMLInputElement;
     this.layersDiv = document.getElementById("background-layers-list") as HTMLDivElement;
+    this.toggleButton = document.getElementById("background-list-checkbox") as HTMLInputElement;
 
     this.input.onchange = (evt) => {
       const file = (evt.target as HTMLInputElement).files?.item(0);
@@ -26,6 +28,8 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
         this.emit("background_upload", file);
       }
     };
+
+    this.toggleButton.addEventListener("change", () => this.toggleList(this.toggleButton.checked));
   }
 
   public update(background: Background) {
@@ -63,8 +67,6 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
         this.emit("background_layer_delete", layer.id);
       };
 
-      li.onclick = () => this.emit("background_layer_select", layer.id);
-
       li.appendChild(nameInput);
       li.appendChild(deleteIcon);
       this.layersDiv.appendChild(li);
@@ -80,6 +82,14 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
     }
 
     this.emit("background_layer_rename", [layer.id, name]);
+  }
+
+  private toggleList(enabled: boolean) {
+    if (enabled) {
+      this.layersDiv.style.display = "";
+    } else {
+      this.layersDiv.style.display = "none";
+    }
   }
 }
 

--- a/client/src/views/backgroundlist.ts
+++ b/client/src/views/backgroundlist.ts
@@ -64,7 +64,7 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
       deleteIcon.classList.add("fa-solid", "fa-trash");
       deleteIcon.onclick = (e) => {
         e.stopPropagation(); // Prevent clicking through the icon onto the li
-        this.emit("background_layer_delete", layer.id);
+        this.onDelete(layer);
       };
 
       li.appendChild(nameInput);
@@ -82,6 +82,12 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
     }
 
     this.emit("background_layer_rename", [layer.id, name]);
+  }
+
+  private onDelete(layer: BackgroundLayer) {
+    if (confirm(`Delete background ${layer.name}?`)) {
+      this.emit("background_layer_delete", layer.id);
+    }
   }
 
   private toggleList(enabled: boolean) {

--- a/client/src/views/backgroundlist.ts
+++ b/client/src/views/backgroundlist.ts
@@ -1,4 +1,6 @@
+import AutosizeInput from "../components/AutosizeInput";
 import { Listener } from "../listener";
+import type { BackgroundLayer } from "../models/background";
 import type Background from "../models/background";
 
 interface BackgroundListViewMap {
@@ -32,23 +34,49 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
     // Iterate in reverse order
     const layers = [...background.layers].reverse();
     for (const layer of layers) {
-      const div = document.createElement("div");
-      const name = document.createElement("p");
+      const li = document.createElement("li");
+      li.id = `background-layer-${layer.id}`;
+      li.style.display = "flex";
+      li.style.justifyContent = "space-between";
+      li.addEventListener("click", () => this.emit("background_layer_select", layer.id));
 
-      div.id = `background-layer-${layer.id}`;
-      div.onclick = () => this.emit("background_layer_select", layer.id);
-      name.innerText = layer.name;
-
-      if (layer.id === background.selected) {
-        name.style.color = "red";
+      if (background.selected === layer.id) {
+        li.classList.add("selected");
       }
 
-      div.appendChild(name);
-      this.layersDiv.appendChild(div);
+      const nameInput = AutosizeInput(layer.name);
+      nameInput.type = "text";
+      nameInput.classList.add("token-name-input");
+      nameInput.maxLength = 36;
+      nameInput.minLength = 1;
+
+      nameInput.addEventListener("click", (e) => e.stopPropagation());
+      nameInput.addEventListener("change", () => this.onRename(layer, nameInput));
+      nameInput.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") nameInput.blur(); // Trigger change-event
+      });
+
+      const deleteIcon = document.createElement("i");
+      deleteIcon.classList.add("fa-solid", "fa-trash");
+      deleteIcon.onclick = () => this.emit("background_layer_delete", layer.id);
+
+      li.onclick = () => this.emit("background_layer_select", layer.id);
+
+      li.appendChild(nameInput);
+      li.appendChild(deleteIcon);
+      this.layersDiv.appendChild(li);
+    }
+  }
+
+  private onRename(layer: BackgroundLayer, input: HTMLInputElement) {
+    const name = input.value.trim();
+    if (layer.name === name) return;
+    if (!name || name.length > input.maxLength || name.length < input.minLength) {
+      input.value = layer.name;
+      return;
     }
 
-    console.log(this.layersDiv);
-    console.log(background);
+    this.emit("background_layer_rename", [layer.id, name]);
   }
 }
 

--- a/client/src/views/backgroundlist.ts
+++ b/client/src/views/backgroundlist.ts
@@ -58,7 +58,10 @@ class BackgroundListView extends Listener<BackgroundListViewMap> {
 
       const deleteIcon = document.createElement("i");
       deleteIcon.classList.add("fa-solid", "fa-trash");
-      deleteIcon.onclick = () => this.emit("background_layer_delete", layer.id);
+      deleteIcon.onclick = (e) => {
+        e.stopPropagation(); // Prevent clicking through the icon onto the li
+        this.emit("background_layer_delete", layer.id);
+      };
 
       li.onclick = () => this.emit("background_layer_select", layer.id);
 

--- a/client/styles/sidebar.css
+++ b/client/styles/sidebar.css
@@ -150,7 +150,7 @@
   }
 
   & .tab-button {
-    height: 100px;
+    height: 120px;
     writing-mode: vertical-rl;
     text-orientation: mixed;
   }

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
         "css"
     ],
     "words": [
+        "backgroundlist",
         "cloudflared",
         "cooldown",
         "Demiplane",

--- a/server/Source/Messages/Background.cs
+++ b/server/Source/Messages/Background.cs
@@ -21,23 +21,23 @@ public class BackgroundAddLayerResponseMessage(BackgroundLayer layer) : Message
     public BackgroundLayer layer = layer;
 }
 
-public class BackgroundSelectLayerRequestMessage(string id) : Message
+public class BackgroundSelectLayerRequestMessage(string? id) : Message
 {
     [JsonProperty(Required = Required.Always)]
     public string type = "request_background_select_layer";
 
-    [JsonProperty(Required = Required.Always)]
-    public string id = id;
+    [JsonProperty(Required = Required.AllowNull)]
+    public string? id = id;
 
 }
 
-public class BackgroundSelectLayerResponseMessage(string id) : Message
+public class BackgroundSelectLayerResponseMessage(string? id) : Message
 {
     [JsonProperty(Required = Required.Always)]
     public string type = "background_select_layer";
 
-    [JsonProperty(Required = Required.Always)]
-    public string id = id;
+    [JsonProperty(Required = Required.AllowNull)]
+    public string? id = id;
 }
 
 public class BackgroundRenameLayerRequestMessage(string id, string name) : Message

--- a/server/Source/Messages/Background.cs
+++ b/server/Source/Messages/Background.cs
@@ -1,0 +1,85 @@
+using Demiplane.Model;
+using Newtonsoft.Json;
+
+namespace Demiplane.Messages;
+
+public class BackgroundAddLayerRequestMessage(BackgroundLayer layer) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "request_background_add_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public BackgroundLayer layer = layer;
+}
+
+public class BackgroundAddLayerResponseMessage(BackgroundLayer layer) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "background_add_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public BackgroundLayer layer = layer;
+}
+
+public class BackgroundSelectLayerRequestMessage(string id) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "request_background_select_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+
+}
+
+public class BackgroundSelectLayerResponseMessage(string id) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "background_select_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+}
+
+public class BackgroundRenameLayerRequestMessage(string id, string name) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "request_background_rename_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+
+    [JsonProperty(Required = Required.Always)]
+    public string name = name;
+}
+
+public class BackgroundRenameLayerResponseMessage(string id, string name) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "background_rename_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+
+    [JsonProperty(Required = Required.Always)]
+    public string name = name;
+}
+
+
+public class BackgroundDeleteLayerRequestMessage(string id) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "request_background_delete_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+
+}
+
+public class BackgroundDeleteLayerResponseMessage(string id) : Message
+{
+    [JsonProperty(Required = Required.Always)]
+    public string type = "background_delete_layer";
+
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+}

--- a/server/Source/Model/Background.cs
+++ b/server/Source/Model/Background.cs
@@ -59,5 +59,10 @@ public class Background(BackgroundLayer[] layers, string? selected)
     public void DeleteLayer(string id)
     {
         layers = [.. layers.Where(layer => layer.id != id)];
+
+        if (id == selected)
+        {
+            selected = null;
+        }
     }
 }

--- a/server/Source/Model/Background.cs
+++ b/server/Source/Model/Background.cs
@@ -2,8 +2,14 @@ using Newtonsoft.Json;
 
 namespace Demiplane.Model;
 
-public class Background(string? href, int width, int height)
+public class BackgroundLayer(string id, string name, string? href, int width, int height)
 {
+    [JsonProperty(Required = Required.Always)]
+    public string id = id;
+
+    [JsonProperty(Required = Required.Always)]
+    public string name = name;
+
     [JsonProperty(Required = Required.AllowNull)]
     public string? href = href;
 
@@ -13,8 +19,45 @@ public class Background(string? href, int width, int height)
     [JsonProperty(Required = Required.Always)]
     public int height = height;
 
+    public BackgroundLayer Clone()
+    {
+        return new(id, name, href, width, height);
+    }
+}
+
+public class Background(BackgroundLayer[] layers, string? selected)
+{
+    [JsonProperty(Required = Required.Always)]
+    public BackgroundLayer[] layers = layers;
+
+    [JsonProperty(Required = Required.AllowNull)]
+    public string? selected = selected;
+
     public Background Clone()
     {
-        return new(href, width, height);
+        BackgroundLayer[] layers = [.. this.layers.Select(layer => layer.Clone())];
+        return new(layers, selected);
+    }
+
+    public void AddLayer(BackgroundLayer layer)
+    {
+        // Check if layer with the id already exists, if it does, raise an error
+        if (layers.FirstOrDefault(l => layer.id == l.id) != null)
+        {
+            throw new ArgumentException($"A layer with id {layer.id} already exists!");
+        }
+
+        layers = [.. layers, layer];
+    }
+
+    public void RenameLayer(string id, string name)
+    {
+        BackgroundLayer layer = layers.FirstOrDefault(layer => layer.id == id) ?? throw new KeyNotFoundException($"Could not find layer with id {id}!");
+        layer.name = name;
+    }
+
+    public void DeleteLayer(string id)
+    {
+        layers = [.. layers.Where(layer => layer.id != id)];
     }
 }

--- a/server/Source/Model/BoardState.cs
+++ b/server/Source/Model/BoardState.cs
@@ -225,6 +225,14 @@ public class ConcurrentBoardState
         }
     }
 
+    public bool BackgroundLayerExists(string id)
+    {
+        lock (_lock)
+        {
+            return _background.layers.FirstOrDefault(layer => layer.id == id) != null;
+        }
+    }
+
     public bool TransformToken(string id, string name, int x, int y, int w, int h, int r)
     {
         lock (_lock)

--- a/server/Source/Model/BoardState.cs
+++ b/server/Source/Model/BoardState.cs
@@ -11,7 +11,7 @@ public class ConcurrentBoardState
     private const int MaxDeletedTokens = 256;
     private readonly List<User> _users = [];
     private readonly Grid _grid = new(64, 0, 0);
-    private readonly Background _background = new(null, 1024, 1024);
+    private readonly Background _background = new([], null);
 
     public bool AddToken(Token token)
     {
@@ -185,13 +185,35 @@ public class ConcurrentBoardState
         }
     }
 
-    public void SetBackground(Background background)
+    public void AddBackgroundLayer(BackgroundLayer layer)
     {
         lock (_lock)
         {
-            _background.href = background.href;
-            _background.width = background.width;
-            _background.height = background.height;
+            _background.AddLayer(layer);
+        }
+    }
+
+    public void SetBackgroundLayer(string? selected)
+    {
+        lock (_lock)
+        {
+            _background.selected = selected;
+        }
+    }
+
+    public void RenameBackgroundLayer(string id, string name)
+    {
+        lock (_lock)
+        {
+            _background.RenameLayer(id, name);
+        }
+    }
+
+    public void DeleteBackgroundLayer(string id)
+    {
+        lock (_lock)
+        {
+            _background.DeleteLayer(id);
         }
     }
 

--- a/server/Source/Server/Messages.cs
+++ b/server/Source/Server/Messages.cs
@@ -126,24 +126,6 @@ public class GridResponseMessage(Grid grid) : Message
     public Grid grid = grid;
 }
 
-public class BackgroundRequestMessage(string href) : Message
-{
-    [JsonProperty(Required = Required.Always)]
-    public string type = "request_background";
-
-    [JsonProperty(Required = Required.Always)]
-    public string href = href;
-}
-
-public class BackgroundResponseMessage(Background background) : Message
-{
-    [JsonProperty(Required = Required.Always)]
-    public string type = "background";
-
-    [JsonProperty(Required = Required.Always)]
-    public Background background = background;
-}
-
 public record struct Transform(string id, string name, int x, int y, int w, int h, int r)
 {
     [JsonProperty(Required = Required.Always)]
@@ -277,19 +259,25 @@ public class MessageJsonConverter : Json.TypeConverter<Message>
         ["create"] = typeof(CreateResponseMessage),
         ["delete"] = typeof(DeleteResponseMessage),
         ["transform"] = typeof(TransformResponseMessage),
-        ["background"] = typeof(BackgroundResponseMessage),
         ["user_change"] = typeof(UserChangeResponseMessage),
         ["layer_change"] = typeof(LayerResponseMessage),
         ["user_disconnect"] = typeof(UserDisconnectResponseMessage),
+        ["background_add_layer"] = typeof(BackgroundAddLayerResponseMessage),
+        ["background_select_layer"] = typeof(BackgroundSelectLayerResponseMessage),
+        ["background_rename_layer"] = typeof(BackgroundRenameLayerResponseMessage),
+        ["background_delete_layer"] = typeof(BackgroundDeleteLayerResponseMessage),
         ["request_sync"] = typeof(SyncRequestMessage),
         ["request_grid"] = typeof(GridRequestMessage),
         ["request_create"] = typeof(CreateRequestMessage),
         ["request_duplicate"] = typeof(DuplicateRequestMessage),
         ["request_delete"] = typeof(DeleteRequestMessage),
         ["request_transform"] = typeof(TransformRequestMessage),
-        ["request_background"] = typeof(BackgroundRequestMessage),
         ["request_user_change"] = typeof(UserChangeRequestMessage),
         ["request_layer_change"] = typeof(LayerRequestMessage),
         ["request_user_position"] = typeof(UserPositionRequestMessage),
+        ["request_background_add_layer"] = typeof(BackgroundAddLayerRequestMessage),
+        ["request_background_select_layer"] = typeof(BackgroundSelectLayerRequestMessage),
+        ["request_background_rename_layer"] = typeof(BackgroundRenameLayerRequestMessage),
+        ["request_background_delete_layer"] = typeof(BackgroundDeleteLayerRequestMessage),
     };
 }

--- a/server/Source/Server/Websocket.cs
+++ b/server/Source/Server/Websocket.cs
@@ -83,7 +83,10 @@ public partial class Server
     /// In order to catch these errors, the most recent messages that did not succeed related
     /// to each token are remembered, such that when the token does finish creating these
     /// changes can be made immediately.
+    /// Similar behavior is also possible for other requests, such as renaming a background
+    /// that doesn't (yet) exist.
     private readonly TimedTokenMessageHistory _latestTokenMessages = new(5000);
+    private readonly TimedBag<string, Message> _latestBackgroundMessages = new(5000);
 
     private async Task HandleWebSocket(HttpContext context)
     {
@@ -141,6 +144,14 @@ public partial class Server
             }
 
             await client.SendAsync(JsonConvert.SerializeObject(message));
+        }
+    }
+
+    private async Task BroadcastMessages(Message[] messages, Socket? ignoreSocket = null)
+    {
+        foreach (Message message in messages)
+        {
+            await BroadcastMessage(message, ignoreSocket);
         }
     }
 
@@ -258,6 +269,9 @@ public partial class Server
                     _state.AddBackgroundLayer(add.layer);
                     BackgroundAddLayerResponseMessage response = new(add.layer);
                     await BroadcastMessage(response, socket);
+
+                    Message[] backgroundMessages = _latestBackgroundMessages.Pop(add.layer.id);
+                    await BroadcastMessages(backgroundMessages, socket);
                     break;
                 }
 
@@ -271,6 +285,11 @@ public partial class Server
 
             case BackgroundRenameLayerRequestMessage rename:
                 {
+                    if (!_state.BackgroundLayerExists(rename.id))
+                    {
+                        _latestBackgroundMessages.Add(rename.id, rename);
+                        break;
+                    }
                     _state.RenameBackgroundLayer(rename.id, rename.name);
                     BackgroundRenameLayerResponseMessage response = new(rename.id, rename.name);
                     await BroadcastMessage(response, socket);
@@ -279,6 +298,11 @@ public partial class Server
 
             case BackgroundDeleteLayerRequestMessage deletion:
                 {
+                    if (!_state.BackgroundLayerExists(deletion.id))
+                    {
+                        _latestBackgroundMessages.Add(deletion.id, deletion);
+                        break;
+                    }
                     _state.DeleteBackgroundLayer(deletion.id);
                     BackgroundDeleteLayerResponseMessage response = new(deletion.id);
                     await BroadcastMessage(response, socket);

--- a/server/Source/Server/Websocket.cs
+++ b/server/Source/Server/Websocket.cs
@@ -253,22 +253,34 @@ public partial class Server
                     break;
                 }
 
-            case BackgroundRequestMessage background:
+            case BackgroundAddLayerRequestMessage add:
                 {
-                    Asset asset =
-                        AssetService.Find(background.href)
-                        ?? throw new FileNotFoundException($"Could not find {background.href}");
+                    _state.AddBackgroundLayer(add.layer);
+                    BackgroundAddLayerResponseMessage response = new(add.layer);
+                    await BroadcastMessage(response, socket);
+                    break;
+                }
 
-                    if (!Image.IsImage(asset.Path))
-                    {
-                        throw new FormatException($"File at {background.href} is not an image!");
-                    }
+            case BackgroundSelectLayerRequestMessage selection:
+                {
+                    _state.SetBackgroundLayer(selection.id);
+                    BackgroundSelectLayerResponseMessage response = new(selection.id);
+                    await BroadcastMessage(response, socket);
+                    break;
+                }
 
-                    (int width, int height) = Image.GetSize(asset.Path);
-                    Background found = new(background.href, width, height);
+            case BackgroundRenameLayerRequestMessage rename:
+                {
+                    _state.RenameBackgroundLayer(rename.id, rename.name);
+                    BackgroundRenameLayerResponseMessage response = new(rename.id, rename.name);
+                    await BroadcastMessage(response, socket);
+                    break;
+                }
 
-                    _state.SetBackground(found);
-                    BackgroundResponseMessage response = new(_state.GetBackground());
+            case BackgroundDeleteLayerRequestMessage deletion:
+                {
+                    _state.DeleteBackgroundLayer(deletion.id);
+                    BackgroundDeleteLayerResponseMessage response = new(deletion.id);
                     await BroadcastMessage(response, socket);
                     break;
                 }

--- a/server/Source/Util/TimedBag.cs
+++ b/server/Source/Util/TimedBag.cs
@@ -1,0 +1,49 @@
+namespace Demiplane.Util;
+
+public class TimedBag<TKey, TValue>(long timeoutMs) where TKey : notnull
+{
+    internal readonly record struct TimedQueueEntry(TValue value, long timestamp)
+    {
+        public readonly TValue value = value;
+        public readonly long timestamp = timestamp;
+    }
+
+    private readonly Dictionary<TKey, List<TimedQueueEntry>> _entries = [];
+    private readonly long _timeoutMs = timeoutMs;
+    private readonly Lock _lock = new();
+
+    private static long Now()
+    {
+        return DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+    }
+
+    public void Add(TKey key, TValue value)
+    {
+        lock (_lock)
+        {
+            if (!_entries.TryGetValue(key, out List<TimedQueueEntry>? entries))
+            {
+                entries = [];
+                _entries[key] = entries;
+            }
+
+            entries.Add(new(value, Now()));
+        }
+    }
+
+    public TValue[] Pop(TKey key)
+    {
+        lock (_lock)
+        {
+            if (!_entries.TryGetValue(key, out List<TimedQueueEntry>? entry))
+            {
+                return [];
+            }
+
+            long now = Now();
+            TValue[] values = [.. entry.FindAll(value => now - value.timestamp < _timeoutMs).Select(value => value.value)];
+            _ = _entries.Remove(key);
+            return values;
+        }
+    }
+}


### PR DESCRIPTION
Adds swappable backgrounds to the map. Only one background can be active at a time, but users can now freely toggle between them with the click of a button. Backgrounds can also be renamed now.

Closes #264 